### PR TITLE
Suggestions for docc fork ordering

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -275,15 +275,13 @@ export DYLD_FALLBACK_LIBRARY_PATH := if os() == "macos" { "/opt/homebrew/lib" } 
 
 # Generate documentation for EELS using docc
 [group('docs')]
-docs-spec:
+docs-spec $DOCC_SKIP_DIFFS="":
     uv run docc --output "{{ output_dir }}/docs-spec"
     uv run python -c 'import pathlib; print("documentation available under file://{0}".format(pathlib.Path(r"{{ output_dir }}") / "docs-spec" / "index.html"))'
 
 # Generate documentation for EELS using docc, skipping the slow per-fork diff render
 [group('docs')]
-docs-spec-fast:
-    DOCC_SKIP_DIFFS=1 uv run docc --output "{{ output_dir }}/docs-spec-fast"
-    uv run python -c 'import pathlib; print("documentation available under file://{0}".format(pathlib.Path(r"{{ output_dir }}") / "docs-spec-fast" / "index.html"))'
+docs-spec-fast: (docs-spec "1")
 
 # Build HTML site documentation with mkdocs
 [group('docs')]

--- a/Justfile
+++ b/Justfile
@@ -279,6 +279,12 @@ docs-spec:
     uv run docc --output "{{ output_dir }}/docs-spec"
     uv run python -c 'import pathlib; print("documentation available under file://{0}".format(pathlib.Path(r"{{ output_dir }}") / "docs-spec" / "index.html"))'
 
+# Generate documentation for EELS using docc, skipping the slow per-fork diff render
+[group('docs')]
+docs-spec-fast:
+    DOCC_SKIP_DIFFS=1 uv run docc --output "{{ output_dir }}/docs-spec-fast"
+    uv run python -c 'import pathlib; print("documentation available under file://{0}".format(pathlib.Path(r"{{ output_dir }}") / "docs-spec-fast" / "index.html"))'
+
 # Build HTML site documentation with mkdocs
 [group('docs')]
 docs *args:

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -77,23 +77,32 @@ def pairwise(iterable: Iterable[G]) -> Iterable[Tuple[G, G]]:
 
 
 class _EthereumListingSource(ListingSource):
-    _key: Final[Tuple[int, PurePath]]
+    _sort: Final[int]
 
     def __init__(
         self,
         relative_path: PurePath,
         output_path: PurePath,
         sources: Set[Source],
-        key: Tuple[int, PurePath],
+        sort: int,
     ) -> None:
         super().__init__(relative_path, output_path, sources)
-        self._key = key
+        self._sort = sort
 
     @override
     def listing_order_key(
         self,
     ) -> Tuple[bool, Tuple[int, PurePath], None]:
-        return (self.is_leaf, self._key, None)
+        return (self.is_leaf, (self._sort, self.output_path), None)
+
+
+def _find_forks(config: PluginSettings) -> List[Hardfork]:
+    forks = config.resolve_path(PurePath("src") / "ethereum" / "forks")
+    return Hardfork.discover([str(forks)])
+
+
+def _diff_path(before: Hardfork, after: Hardfork) -> PurePath:
+    return PurePath("diffs") / before.short_name / after.short_name
 
 
 class EthereumListingDiscover(ListingDiscover):
@@ -102,20 +111,28 @@ class EthereumListingDiscover(ListingDiscover):
     chronological order.
     """
 
-    fork_order: Dict[str, int]
+    fork_order: List[PurePath]
+    diff_order: List[PurePath]
 
     def __init__(self, config: PluginSettings) -> None:
         super().__init__(config)
-        base = config.resolve_path(PurePath("src") / "ethereum")
-        forks = Hardfork.discover([str(base / "forks")])
-        self.fork_order = {f.short_name: i for i, f in enumerate(forks)}
+        forks = _find_forks(config)
+        self.fork_order = [
+            config.unresolve_path(PurePath(f.path))
+            for f in forks
+            if f.path is not None
+        ]
+        self.diff_order = [_diff_path(b, a).parent for b, a in pairwise(forks)]
 
     def _fork_index(self, parent: PurePath) -> Optional[int]:
-        parts = parent.parts
-        if len(parts) == 2 and parts[0] == "diffs":
-            return self.fork_order.get(parts[1])
-        if len(parts) == 4 and parts[:3] == ("src", "ethereum", "forks"):
-            return self.fork_order.get(parts[3])
+        for idx, fork in enumerate(self.fork_order):
+            if parent.is_relative_to(fork):
+                return idx
+
+        for idx, diff in enumerate(self.diff_order):
+            if parent.is_relative_to(diff):
+                return idx
+
         return None
 
     @override
@@ -129,7 +146,7 @@ class EthereumListingDiscover(ListingDiscover):
             parent,
             parent / "index",
             set(),
-            (index, parent / "index"),
+            -index,  # Reverse chronological order
         )
 
 
@@ -144,9 +161,7 @@ class EthereumDiscover(Discover):
 
     def __init__(self, config: PluginSettings) -> None:
         self.settings = config
-        base = config.resolve_path(PurePath("src") / "ethereum")
-        forks = base / "forks"
-        self.forks = Hardfork.discover([str(forks)])
+        self.forks = _find_forks(config)
 
     def discover(self, known: FrozenSet[T]) -> Iterator[Source]:
         """
@@ -199,12 +214,7 @@ class EthereumDiscover(Discover):
 
                 assert before_source or after_source
 
-                output_path = (
-                    PurePath("diffs")
-                    / before.short_name
-                    / after.short_name
-                    / path
-                )
+                output_path = _diff_path(before, after) / path
 
                 yield DiffSource(
                     before.name,

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -125,6 +125,14 @@ class EthereumListingDiscover(ListingDiscover):
     chronological order.
     """
 
+    fork_order: Dict[str, int]
+
+    def __init__(self, config: PluginSettings) -> None:
+        super().__init__(config)
+        base = config.resolve_path(PurePath("src") / "ethereum")
+        forks = Hardfork.discover([str(base / "forks")])
+        self.fork_order = {f.short_name: i for i, f in enumerate(forks)}
+
     @override
     def _listing_source(
         self, source: Source, parent: PurePath
@@ -142,6 +150,19 @@ class EthereumListingDiscover(ListingDiscover):
                 parent / "index",
                 set(),
                 source._key,
+            )
+        elif (
+            len(parent.parts) == 4
+            and parent.parts[:3] == ("src", "ethereum", "forks")
+            and parent.parts[3] in self.fork_order
+        ):
+            return _EthereumListingSource(
+                parent,
+                parent / "index",
+                set(),
+                _EthereumSort(
+                    self.fork_order[parent.parts[3]], parent / "index"
+                ),
             )
         else:
             return super()._listing_source(source, parent)

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 Ethereum Foundation
+# Copyright (C) 2022-2023,2026 Ethereum Foundation
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,9 @@ import dataclasses
 import logging
 import os
 from collections import defaultdict
-from functools import total_ordering
 from itertools import tee, zip_longest
 from pathlib import PurePath
 from typing import (
-    TYPE_CHECKING,
     Dict,
     Final,
     FrozenSet,
@@ -66,28 +64,7 @@ from typing_extensions import assert_never, override
 
 from .forks import Hardfork
 
-if TYPE_CHECKING:
-    from typing import Any
-
-    from _typeshed import SupportsDunderGT, SupportsDunderLT
-
-
 G = TypeVar("G")
-
-
-@total_ordering
-@dataclasses.dataclass(frozen=True)
-class _EthereumSort:
-    sort_order: int
-    path: PurePath
-
-    def __lt__(self, other: Union[PurePath, "_EthereumSort"]) -> bool:
-        if isinstance(other, _EthereumSort):
-            return (self.sort_order, self.path) < (
-                other.sort_order,
-                other.path,
-            )
-        return self.path < other
 
 
 def pairwise(iterable: Iterable[G]) -> Iterable[Tuple[G, G]]:
@@ -100,14 +77,14 @@ def pairwise(iterable: Iterable[G]) -> Iterable[Tuple[G, G]]:
 
 
 class _EthereumListingSource(ListingSource):
-    _key: Final[_EthereumSort]
+    _key: Final[Tuple[int, PurePath]]
 
     def __init__(
         self,
         relative_path: PurePath,
         output_path: PurePath,
         sources: Set[Source],
-        key: _EthereumSort,
+        key: Tuple[int, PurePath],
     ) -> None:
         super().__init__(relative_path, output_path, sources)
         self._key = key
@@ -115,7 +92,7 @@ class _EthereumListingSource(ListingSource):
     @override
     def listing_order_key(
         self,
-    ) -> Union["SupportsDunderGT[Any]", "SupportsDunderLT[Any]"]:
+    ) -> Tuple[bool, Tuple[int, PurePath], None]:
         return (self.is_leaf, self._key, None)
 
 
@@ -133,39 +110,27 @@ class EthereumListingDiscover(ListingDiscover):
         forks = Hardfork.discover([str(base / "forks")])
         self.fork_order = {f.short_name: i for i, f in enumerate(forks)}
 
+    def _fork_index(self, parent: PurePath) -> Optional[int]:
+        parts = parent.parts
+        if len(parts) == 2 and parts[0] == "diffs":
+            return self.fork_order.get(parts[1])
+        if len(parts) == 4 and parts[:3] == ("src", "ethereum", "forks"):
+            return self.fork_order.get(parts[3])
+        return None
+
     @override
     def _listing_source(
         self, source: Source, parent: PurePath
     ) -> ListingSource:
-        if isinstance(source, DiffSource):
-            return _EthereumListingSource(
-                parent,
-                parent / "index",
-                set(),
-                _EthereumSort(source._sort, parent / "index"),
-            )
-        elif isinstance(source, _EthereumListingSource):
-            return _EthereumListingSource(
-                parent,
-                parent / "index",
-                set(),
-                source._key,
-            )
-        elif (
-            len(parent.parts) == 4
-            and parent.parts[:3] == ("src", "ethereum", "forks")
-            and parent.parts[3] in self.fork_order
-        ):
-            return _EthereumListingSource(
-                parent,
-                parent / "index",
-                set(),
-                _EthereumSort(
-                    self.fork_order[parent.parts[3]], parent / "index"
-                ),
-            )
-        else:
+        index = self._fork_index(parent)
+        if index is None:
             return super()._listing_source(source, parent)
+        return _EthereumListingSource(
+            parent,
+            parent / "index",
+            set(),
+            (index, parent / "index"),
+        )
 
 
 class EthereumDiscover(Discover):
@@ -224,7 +189,7 @@ class EthereumDiscover(Discover):
             by_fork[fork][fork_relative_path] = source
 
         diff_count = 0
-        for sort, (before, after) in enumerate(pairwise(self.forks)):
+        for before, after in pairwise(self.forks):
             paths = set(by_fork[before].keys()) | set(by_fork[after].keys())
 
             for path in paths:
@@ -247,7 +212,6 @@ class EthereumDiscover(Discover):
                     after.name,
                     after_source,
                     output_path,
-                    sort=sort,
                 )
 
         if 0 == diff_count:
@@ -271,8 +235,6 @@ class DiffSource(Generic[S], Source, Listable):
     after: Optional[S]
     _output_path: PurePath
 
-    _sort: int
-
     def __init__(
         self,
         before_name: str,
@@ -280,7 +242,6 @@ class DiffSource(Generic[S], Source, Listable):
         after_name: str,
         after: Optional[S],
         output_path: PurePath,
-        sort: int,
     ) -> None:
         self.before_name = before_name
         self.before = before
@@ -289,7 +250,6 @@ class DiffSource(Generic[S], Source, Listable):
         self.after = after
 
         self._output_path = output_path
-        self._sort = sort
 
     @property
     def show_in_listing(self) -> bool:

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -72,8 +72,6 @@ docc._HardenVisitor.enter
 docc._MinimizeDiffsVisitor.enter
 docc.render_diff
 docc.render_before_after
-docc.SupportsDunderGT
-docc.SupportsDunderLT
 docc._EthereumListingSource.listing_order_key
 
 # src/ethereum_spec_tools/evm_tools/daemon.py


### PR DESCRIPTION
Hey Sam, I wondered if we could simplify the ordering a little. It took me a while to understand so had a play around and landed up with this.

- The first commit adds a `docs-spec-fast` recipe (it's only setting `DOCC_SKIP_DIFFS=1`, so a little over the top, but it makes it easier for newcomers and agents to discover, I guess).
- Second commit also adds sorting for `./src/ethereum/forks/index.html`.
- The third commit is the simplification. It avoids comparison with heterogeneous keys (specifically comparison against `PurePath` items) by only overriding the `_listing_source` when `./diffs/` or `./src/ethereum/forks/` is a parent. Then we can make the comparison simpler and avoid propagating the sort key up the parent chain.